### PR TITLE
Fixed typographical error, changed anyhwere to anywhere in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ including the sample markup provided
 ### Options ###
 
 You don't really need a comment for the options object itself, since the options object is a standard 
-jQuery UI convention.  You can include one, but it doesn't get shown anyhwere in the documentation.
+jQuery UI convention.  You can include one, but it doesn't get shown anywhere in the documentation.
 
 Comments for the individual options are used however.  You can provide descriptions.  The default value is 
 pulled automatically from the code, but you can override it if you specify a  ```@default``` tag.


### PR DESCRIPTION
@jannon, I've corrected a typographical error in the documentation of the [JSDoc-JUI](https://github.com/jannon/JSDoc-JUI) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
